### PR TITLE
Make server configurable via clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -319,6 +320,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4"
 bincode = "1.3"   
 rmp-serde = "0.15"
 serde_json = "1.0"
-clap = "4.5"
+clap = { version = "4.5", features = ["derive"] }
 log = "0.4.21"
 env_logger = "0.11.3"
 futures = "0.3.30"


### PR DESCRIPTION
This makes the server configurable from the CLI
```
Usage: server [OPTIONS]

Options:
  -l, --listen-ip <LISTEN_IP>      [default: 0.0.0.0]
  -p, --port <PORT>                [default: 7777]
  -m, --max-history <MAX_HISTORY>  [default: 5]
  -h, --help                       Print help
  -V, --version                    Print version
```


Ameliorates #5